### PR TITLE
chore: ソースコードのコメントに残るドキュメントファイル参照を削除する

### DIFF
--- a/frontend/src/widgets/step-player/lib/stepFilters.ts
+++ b/frontend/src/widgets/step-player/lib/stepFilters.ts
@@ -2,7 +2,9 @@ import type { MatchingEvent, MatchingStepSnapshot } from "../../../entities/matc
 
 /**
  * イベント種別フィルタ。`"all"` は全種別を対象とする（フィルタなし）。
- * 値は docs/event-schema.md の `EventType` と対応する。
+ * 各値はマッチングアルゴリズムのイベントログにおける種別を表す:
+ * `propose`=提案、`tentative_accept`=仮受入、`reject`=棄却、`waitlist`=待機、
+ * `promote`=繰り上げ、`cutoff_raise`=カットオフ引き上げ。
  */
 export type EventTypeFilter =
   | "all"


### PR DESCRIPTION
## 関連イシュー

- Close #58

## 変更内容

- `frontend/src/widgets/step-player/lib/stepFilters.ts` の `EventTypeFilter` の冒頭コメントから `docs/event-schema.md` への参照を削除し、各イベント種別（`propose`/`tentative_accept`/`reject`/`waitlist`/`promote`/`cutoff_raise`）の意味をコメント内で自己完結して説明する形に書き換えた

## 変更理由

- コーディング規約（ソースコードにドキュメントファイル名・イシュー番号を記述しない）に反する参照が1箇所残っていたため。ドキュメント構成の変更のたびに参照が陳腐化し、実装だけを読む開発者・エージェントが実体を確認できなくなる問題を解消する

## 動作確認方法

- `backend/src/**/*.py`・`frontend/src/**/*.ts`・`*.tsx`（`__pycache__` 除く）を対象に `docs/*.md`・`.claude/rules/*.md` への参照、および `#NN` 形式のイシュー番号参照を grep で再走査し、実質0件であることを確認した（フロントエンド側のヒットはカラーコード `#94a3b8` 等の誤検出のみ）
- 品質ゲート（backend: ruff check/format・mypy・lint-imports・pytest、frontend: lint・typecheck・test・steiger・build）をすべて実行し、全通過を確認した（セルフレビューでも独立に再実行し全通過を確認済み）
- コメントのみの変更のため実行時の挙動に影響はなく、新規テストは追加していない（`.claude/rules/testing.md` の方針に基づく）

## レビュー観点

- 新コメントは各値を単語レベルの訳語（例: `waitlist`=待機、`promote`=繰り上げ）で説明しており、`docs/event-schema.md` の表にある「どのアルゴリズム（FDA/CA）でのみ発生するか」「`tentative_accept` は最終ラウンドで確定受入になる」といった補足情報までは持ち込んでいない。ソースコード単体を読む開発者・エージェントがこの粒度で十分か
- 今回のような要約レベルの自己完結説明で足りるという判断が、今後 `docs/event-schema.md` の記述を変更する際に本コメントが追随更新されるか、というバランスとして妥当か

## 懸念点

- 特になし。コメントのみの変更で実行時挙動に影響がなく、品質ゲート・完了条件（ドキュメントファイル名・イシュー番号参照0件）ともにセルフレビューで独立検証済み（ennx-reviewer による総合判定: Ready for review 可、high指摘0件）

## その他

- マージ順（スタックPRの場合）: 該当なし（依存イシューなし）
